### PR TITLE
feat)mission page gating basic func added

### DIFF
--- a/app/config/routes.js
+++ b/app/config/routes.js
@@ -116,6 +116,9 @@ angular
             },
             missionData: function(Missions, $stateParams) {
               return Missions.getShuffleData($stateParams.courseName);
+            },
+            lastEle: function(Missions) {
+              return Missions.getLastElement();
             }
           }
         })
@@ -143,6 +146,16 @@ angular
             },
             accordionData: function(AccordionService) {
               return AccordionService.getLessons();
+            }
+          }
+        })
+        .state('missionComplete', {
+          templateUrl: 'lessons/missioncomplete.html',
+          resolve: {
+            auth: function($state, Users, Auth) {
+              return Auth.$requireAuth().catch(function() {
+                $state.go('home');
+              });
             }
           }
         })

--- a/app/lessons/mission.service.js
+++ b/app/lessons/mission.service.js
@@ -16,6 +16,7 @@
 
       var Mission = {};
       Mission.getShuffleData = getShuffleData;
+      Mission.getLastElement = getLastElement;
 
       return Mission;
 
@@ -30,7 +31,14 @@
         });
         return defer.promise;
       };
+      function getLastElement(){
+        var defer = $q.defer();
+        ref.orderByChild('sequence').limitToLast(1).on('value', function(snapshot){
+          defer.resolve(snapshot.val());
+        });
 
+        return defer.promise;
+      }
     };
 
 })();

--- a/app/lessons/mission.template.bak.html
+++ b/app/lessons/mission.template.bak.html
@@ -1,0 +1,83 @@
+<div app-header></div>
+
+<div class="container-fluid">
+  <div class="row">
+
+    <!-- Shuffle Title -->
+    <h3> {{ missionCtrl.title }} </h3>
+
+    <!-- ng repeat -->
+    <div class="col-md-12" ng-repeat="element in missionCtrl.elements" ng-if="(element.sequence<=currentSequence)">
+    
+      <!-- Switch to check type and display accordingly -->
+      <div ng-switch on="element.type">
+        <p class="missionsequence" ng-show="missionCtrl.isAdmin() && missionCtrl.isBuildMode()">{{element.sequence}}</p>
+        <div ng-switch-when="text" class="element-text">
+          <h3> {{ element.title }} </h3>
+
+
+          <div ng-bind-html="element.content"></div>
+          <button class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Continue</button>
+        </div>
+
+        <div ng-switch-when="image" class="element-images">
+          <img style="width: 500px; height: 300px; display: block" ng-src=" {{element.url}} " />
+          <button class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Continue</button>
+        </div>
+
+        <div ng-switch-when="video" class="element-video">
+          <p> {{ element.mediaUrl }} (will be iFrame) </p>
+          <button class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Continue</button>
+        </div>
+
+        <div ng-switch-when="code" class="element-code">
+          <pre> {{ element.content }} </pre>
+          <button class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Continue</button>
+        </div>
+
+        <div ng-switch-when="question" class="element-question">
+
+
+          <div>
+            <form name="form" class="css-form" novalidate>
+              <p> {{ element.prompt }} </p>
+              Answer:
+              <br />
+              <input type="radio" ng-model="response" value="a" />{{element.answer.a}}
+              <br />
+              <input type="radio" ng-model="response" value="b" />{{element.answer.b}}
+              <br />
+              <input type="radio" ng-model="response" value="c" ng-show="element.answer.c" />{{element.answer.c}}
+              <br />
+              <input type="radio" ng-model="response" value="d" ng-show="element.answer.d" />{{element.answer.d}}
+              <br />
+            </form>
+            <button ng-show="element.answer.correct === response" class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Great Job - Continue</button>
+            <code ng-show="response && element.answer.correct !== response">Try Again!</code>
+          </div>
+
+
+        </div>
+
+        <div ng-switch-when="code-editor" class="element-code-editor">
+          {{missionCtrl.initEditor(element.prompt)}}
+          <div id="code-editor"></div>
+          <div id="result" ng-show="missionCtrl.codeResult">
+          </div>
+          <button class="btn btn-default btn-large" ng-click="missionCtrl.reset(element.prompt)">reset</button>
+          <button class="btn btn-default btn-large" ng-click="missionCtrl.run(element.testCase)">run</button>
+          <br />
+          <button class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Continue</button>
+        </div>
+
+        <div ng-switch-when="list" class="element-list">
+          <ul>{{ element.content }}</ul>
+            <button class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Continue</button>
+        </div>
+
+      </div>
+    <!-- END ng-repeat -->
+    </div>
+    <button class="btn btn-default btn-large" ui-sref="mission({ courseName: missionCtrl.nextShuffle })" ng-click="missionCtrl.saveElement( missionCtrl.sequence )">Next Lesson</button>
+  </div>
+</div>

--- a/app/lessons/mission.template.html
+++ b/app/lessons/mission.template.html
@@ -2,81 +2,81 @@
 
 <div class="container-fluid">
   <div class="row">
+    <div class="col-md-1"></div>
+    <div class="col-md-10">
+      <h3 class="missiontitle"> {{ missionCtrl.title }} </h3>
+      <!-- ng repeat -->
+      <!-- <div class="col-md-1"></div> -->
+      <div ng-repeat="element in missionCtrl.elements">
+        <!-- Shuffle Title -->
+        <!-- Switch to check type and display accordingly -->
+        <div ng-switch on="element.type">
+          <p class="missionsequence" ng-show="missionCtrl.isAdmin() && missionCtrl.isBuildMode()">{{element.sequence}}</p>
+          <div ng-switch-when="text" class="element-text">
+            <h3> {{ element.title }} </h3>
 
-    <!-- Shuffle Title -->
-    <h3> {{ missionCtrl.title }} </h3>
-
-    <!-- ng repeat -->
-    <div class="col-md-12" ng-repeat="element in missionCtrl.elements" ng-if="(element.sequence<=currentSequence)">
-      <!-- Switch to check type and display accordingly -->
-      <div ng-switch on="element.type">
-        <p class="missionsequence" ng-show="missionCtrl.isAdmin() && missionCtrl.isBuildMode()">{{element.sequence}}</p>
-        <div ng-switch-when="text" class="element-text">
-          <h3> {{ element.title }} </h3>
-
-
-          <div ng-bind-html="element.content"></div>
-          <button class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Continue</button>
-        </div>
-
-        <div ng-switch-when="image" class="element-images">
-          <img style="width: 500px; height: 300px; display: block" ng-src=" {{element.url}} " />
-          <button class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Continue</button>
-        </div>
-
-        <div ng-switch-when="video" class="element-video">
-          <p> {{ element.mediaUrl }} (will be iFrame) </p>
-          <button class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Continue</button>
-        </div>
-
-        <div ng-switch-when="code" class="element-code">
-          <pre> {{ element.content }} </pre>
-          <button class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Continue</button>
-        </div>
-
-        <div ng-switch-when="question" class="element-question">
-
-
-          <div>
-            <form name="form" class="css-form" novalidate>
-              <p> {{ element.prompt }} </p>
-              Answer:
-              <br />
-              <input type="radio" ng-model="response" value="a" />{{element.answer.a}}
-              <br />
-              <input type="radio" ng-model="response" value="b" />{{element.answer.b}}
-              <br />
-              <input type="radio" ng-model="response" value="c" ng-show="element.answer.c" />{{element.answer.c}}
-              <br />
-              <input type="radio" ng-model="response" value="d" ng-show="element.answer.d" />{{element.answer.d}}
-              <br />
-            </form>
-            <button ng-show="element.answer.correct === response" class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Great Job - Continue</button>
-            <code ng-show="response && element.answer.correct !== response">Try Again!</code>
+            <div ng-bind-html="element.content"></div>
+            <!-- <button class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Continue</button> -->
           </div>
 
-
-        </div>
-
-        <div ng-switch-when="code-editor" class="element-code-editor">
-          {{missionCtrl.initEditor(element.prompt)}}
-          <div id="code-editor"></div>
-          <div id="result" ng-show="missionCtrl.codeResult">
+          <div ng-switch-when="image" class="element-images">
+            <img style="width: 500px; height: 300px; display: block" ng-src=" {{element.url}} " />
+            <!-- <button class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Continue</button> -->
           </div>
-          <button class="btn btn-default btn-large" ng-click="missionCtrl.reset(element.prompt)">reset</button>
-          <button class="btn btn-default btn-large" ng-click="missionCtrl.run(element.testCase)">run</button>
-          <br />
-          <button class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Continue</button>
-        </div>
 
-        <div ng-switch-when="list" class="element-list">
-          <ul>{{ element.content }}</ul>
-            <button class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Continue</button>
-        </div>
+          <div ng-switch-when="video" class="element-video">
+            <p> {{ element.mediaUrl }} (will be iFrame) </p>
+            <!-- <button class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Continue</button> -->
+          </div>
 
-      </div>
-    <!-- END ng-repeat -->
+          <div ng-switch-when="code" class="element-code">
+            <pre> {{ element.content }} </pre>
+            <!-- <button class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Continue</button> -->
+          </div>
+
+          <div ng-switch-when="question" class="element-question">
+
+            <div>
+              <form name="form" class="css-form" novalidate>
+                <p> {{ element.prompt }} </p>
+                Answer:
+                <br />
+                <input type="radio" ng-model="missionCtrl.answerResponse" value="a" />  {{element.answer.a}}
+                <br />
+                <input type="radio" ng-model="missionCtrl.answerResponse" value="b" />  {{element.answer.b}}
+                <br />
+                <input type="radio" ng-model="missionCtrl.answerResponse" value="c" ng-show="element.answer.c" />  {{element.answer.c}}
+                <br />
+                <input type="radio" ng-model="missionCtrl.answerResponse" value="d" ng-show="element.answer.d" />  {{element.answer.d}}
+                <br />
+              </form>
+              <!-- <button ng-show="element.answer.correct === response" class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Great Job - Continue</button> -->
+              <code ng-show="missionCtrl.answerResponse && element.answer.correct !== answerResponse">Try Again!</code>
+              <!-- {{missionCtrl.answerResponse}} -->
+            </div>
+
+          </div>
+
+          <div ng-switch-when="code-editor">
+            {{missionCtrl.initEditor(element.prompt)}}
+            <div id="code-editor" class="codeeditorbox"></div>
+            <div id="result" ng-show="missionCtrl.codeResult">
+            </div>
+            <button class="btn btn-primary btn-sm" ng-click="missionCtrl.run(element.testCase)">Run</button>
+            <button class="btn btn-warning btn-sm" ng-click="missionCtrl.reset(element.prompt)">Reset</button>
+            <button class="btn btn-danger btn-sm" ng-click="missionCtrl.showCodeAnswer(element.answer)">Show Answer</button>
+            <br />
+            <!-- <button class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Continue</button> -->
+          </div>
+
+          <div ng-switch-when="list" class="element-list">
+            <ul>{{ element.content }}</ul>
+              <!-- <button class="btn btn-default btn-large" ng-click="missionCtrl.saveElement( element.sequence )">Continue</button> -->
+          </div>
+        </div>
+      </div><!-- END ng-repeat -->
+      <button ng-show="!missionCtrl.gate.gateNeededEleNum || missionCtrl.answerResponse" class="nextbotton btn btn-default btn-large" ui-sref="mission({ courseName: missionCtrl.nextShuffle })" ng-click="missionCtrl.saveElement( missionCtrl.sequence )">Next Lesson</button>
     </div>
-    <button class="btn btn-default btn-large" ui-sref="mission({ courseName: missionCtrl.nextShuffle })" ng-click="missionCtrl.saveElement( missionCtrl.sequence )">Next Lesson</button>
+    <div class="col-md-1"></div>
   </div>
 </div>

--- a/app/lessons/missioncomplete.html
+++ b/app/lessons/missioncomplete.html
@@ -1,0 +1,11 @@
+<div app-header></div>
+
+<div class="container">
+  <div class="row">
+    <br />
+    <h1 class="text-center">Congraturations!</h1>  
+    <h2 class="text-center">You have completed the neural network lesson.</h2>
+    <br />
+    <button class="btn btn-primary btn-md center-block" ui-sref="accordion">Go back to the main page</button>
+  </div>
+</div>

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -350,7 +350,7 @@ body {
   text-align: right;
   color: #aaa;
   font-size: 0.8em;
-  position:absolute;
+  
   top:-15px;
   right: 20px;
 }
@@ -364,12 +364,21 @@ body {
   bottom: 0;
   left: 0;
   height: 300px;
-  width: 600px;
+  margin-bottom: 5px;
+  border-radius: 3px;
 }
 #result {
-  background-color: #aaa;
+  /*background-color: #aaa;*/
   position: relative;
-  width: 600px;
+  
+}
+.nextbotton{
+  margin-top: 10px;
+}
+
+.missiontitle{
+  margin-left: 20px;
+  padding-top: 10px;
 }
 /*----------------------------------------------------------*/
 /*                       Style Classes                      */


### PR DESCRIPTION
added 
1. missing gating basic feature : course that has code-editor and answer type elements will not show next button until you solve code-editor and answer the answer type question(answer type question in bug)
   - basic gating will be done by counting elements that are required to be solved before proceeding further(code-editor, question elements)
   - openGate function will decrement gateNeededEleNum and when gateNeededEleNum = 0, next session button will appear. 
   - testcase answer block in code-editor element will have openGate() to it will decrement it.
   - currently answer type does not work well with this way. need to figure out.
2. style for mission page
3. completed paged
4. clicking on next session on the last course will be redirected to lessonComplete page

bug remaining
1. course with two code-editor block will not display properly and thus "next session' button won't wrok.? consider having one code block per page or need to figure out work around.
